### PR TITLE
Expose configurable elaboration delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,11 @@
 					"type": "number",
 					"default": -1,
 					"markdownDescription": "Index of the filter applied to the tactic state (in the array infoViewTacticStateFilters). An index of -1 means no filter is applied."
+				},
+				"lean4.elaborationDelay": {
+					"type": "number",
+					"default": 200,
+					"description": "Time (in milliseconds) which must pass since latest edit until elaboration begins. Lower values may make editing feel faster at the cost of higher CPU usage."
 				}
 			}
 		},

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,3 +65,7 @@ export function getInfoViewTacticStateFilters(): InfoViewTacticStateFilter[] {
 export function getInfoViewFilterIndex(): number {
     return workspace.getConfiguration('lean4').get('infoViewFilterIndex', -1);
 }
+
+export function getElaborationDelay(): number {
+    return workspace.getConfiguration('lean4').get('elaborationDelay', 200);
+}

--- a/src/leanclient.ts
+++ b/src/leanclient.ts
@@ -9,7 +9,7 @@ import {
     ServerOptions
 } from 'vscode-languageclient/node'
 import * as ls from 'vscode-languageserver-protocol'
-import { executablePath, addServerEnvPaths, serverLoggingEnabled, serverLoggingPath } from './config'
+import { executablePath, addServerEnvPaths, serverLoggingEnabled, serverLoggingPath, getElaborationDelay } from './config'
 import { PlainGoal, ServerProgress } from './leanclientTypes'
 import { assert } from './utils/assert'
 import * as path from 'path'
@@ -76,6 +76,9 @@ export class LeanClient implements Disposable {
         }
         const clientOptions: LanguageClientOptions = {
             documentSelector: [documentSelector],
+            initializationOptions: {
+                editDelay: getElaborationDelay(),
+            },
             middleware: {
                 handleDiagnostics: (uri, diagnostics, next) => {
                     const processedUntil = diagnostics.find((d) =>


### PR DESCRIPTION
Users may set how long they wish the server to wait after the last edit before starting elaboration. See also Zulip [thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Has.20Lean.204.20gotten.20slower.3F).