### PR TITLE
fix: packaging

### DIFF
--- a/vscode-lean4/.vscodeignore
+++ b/vscode-lean4/.vscodeignore
@@ -7,3 +7,5 @@
 !media
 !images
 !syntaxes
+!package.json
+!language-configuration.json

--- a/vscode-lean4/package-lock.json
+++ b/vscode-lean4/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lean4",
-	"version": "0.0.31",
+	"version": "0.0.32",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lean4",
-			"version": "0.0.31",
+			"version": "0.0.32",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"mobx": "5.15.7",
@@ -23,7 +23,7 @@
 				"ts-loader": "^8.3.0",
 				"typescript": "^4.3.4",
 				"utf-8-validate": "^5.0.5",
-				"vsce": "~1.91.0",
+				"vsce": "~1.95.0",
 				"webpack": "^5.40.0",
 				"webpack-cli": "^4.7.2"
 			},
@@ -2396,9 +2396,9 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3520,12 +3520,12 @@
 			"dev": true
 		},
 		"node_modules/vsce": {
-			"version": "1.91.0",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.91.0.tgz",
-			"integrity": "sha512-y75QryWKzAw5KIR4NFEXc6XAy/Er1BHXdNwAESgKKFw8Yc8cA/+dP4Gj7VYhNPOJlV0v5j1in/cPkLFZAqC7cQ==",
+			"version": "1.95.1",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.95.1.tgz",
+			"integrity": "sha512-2v8g3ZtZkaOTscRjjCAtM3Au6YYWJtg9UNt1iyyWko7ZHejbt5raClcNzQ7/WYVLYhYHc+otHQifV0gCBREgNg==",
 			"dev": true,
 			"dependencies": {
-				"azure-devops-node-api": "^10.2.2",
+				"azure-devops-node-api": "^11.0.1",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
 				"commander": "^6.1.0",
@@ -3540,7 +3540,7 @@
 				"parse-semver": "^1.1.1",
 				"read": "^1.0.7",
 				"semver": "^5.1.0",
-				"tmp": "0.0.29",
+				"tmp": "^0.2.1",
 				"typed-rest-client": "^1.8.4",
 				"url-join": "^1.1.0",
 				"yauzl": "^2.3.1",
@@ -3566,9 +3566,9 @@
 			}
 		},
 		"node_modules/vsce/node_modules/azure-devops-node-api": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
-			"integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.0.1.tgz",
+			"integrity": "sha512-YMdjAw9l5p/6leiyIloxj3k7VIvYThKjvqgiQn88r3nhT93ENwsoDS3A83CyJ4uTWzCZ5f5jCi6c27rTU5Pz+A==",
 			"dev": true,
 			"dependencies": {
 				"tunnel": "0.0.6",
@@ -3641,6 +3641,18 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/vsce/node_modules/tmp": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+			"dev": true,
+			"dependencies": {
+				"rimraf": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8.17.0"
 			}
 		},
 		"node_modules/vsce/node_modules/tunnel": {
@@ -5731,9 +5743,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
 			"dev": true
 		},
 		"once": {
@@ -6571,12 +6583,12 @@
 			"dev": true
 		},
 		"vsce": {
-			"version": "1.91.0",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.91.0.tgz",
-			"integrity": "sha512-y75QryWKzAw5KIR4NFEXc6XAy/Er1BHXdNwAESgKKFw8Yc8cA/+dP4Gj7VYhNPOJlV0v5j1in/cPkLFZAqC7cQ==",
+			"version": "1.95.1",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.95.1.tgz",
+			"integrity": "sha512-2v8g3ZtZkaOTscRjjCAtM3Au6YYWJtg9UNt1iyyWko7ZHejbt5raClcNzQ7/WYVLYhYHc+otHQifV0gCBREgNg==",
 			"dev": true,
 			"requires": {
-				"azure-devops-node-api": "^10.2.2",
+				"azure-devops-node-api": "^11.0.1",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
 				"commander": "^6.1.0",
@@ -6591,7 +6603,7 @@
 				"parse-semver": "^1.1.1",
 				"read": "^1.0.7",
 				"semver": "^5.1.0",
-				"tmp": "0.0.29",
+				"tmp": "^0.2.1",
 				"typed-rest-client": "^1.8.4",
 				"url-join": "^1.1.0",
 				"yauzl": "^2.3.1",
@@ -6608,9 +6620,9 @@
 					}
 				},
 				"azure-devops-node-api": {
-					"version": "10.2.2",
-					"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
-					"integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
+					"version": "11.0.1",
+					"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.0.1.tgz",
+					"integrity": "sha512-YMdjAw9l5p/6leiyIloxj3k7VIvYThKjvqgiQn88r3nhT93ENwsoDS3A83CyJ4uTWzCZ5f5jCi6c27rTU5Pz+A==",
 					"dev": true,
 					"requires": {
 						"tunnel": "0.0.6",
@@ -6668,6 +6680,15 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
+					}
+				},
+				"tmp": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+					"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+					"dev": true,
+					"requires": {
+						"rimraf": "^3.0.0"
 					}
 				},
 				"tunnel": {

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -378,7 +378,7 @@
 		"ts-loader": "^8.3.0",
 		"typescript": "^4.3.4",
 		"utf-8-validate": "^5.0.5",
-		"vsce": "~1.91.0",
+		"vsce": "~1.95.0",
 		"webpack": "^5.40.0",
 		"webpack-cli": "^4.7.2"
 	},


### PR DESCRIPTION
We were missing some extra configuration in the `.vsix` package which broke language features as reported on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/ctrl-.2F.20.22toggle.20comment.22.20broken.20in.20vscode-lean4.200.2E0.2E32). Also pins a newer version of VSCE which [unbreaks](https://github.com/microsoft/vscode-vsce/commit/599cea7eb50ef43548c253633fd3dbabd4289c87) the `.vscodeignore` behaviour.