### PR TITLE
feat: support server RPC refs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,7 @@
     "eslint.workingDirectories": [
         "./lean4-infoview",
         "./vscode-lean4",
-    ]
+    ],
+    "files.insertFinalNewline": true,
+    "files.trimTrailingWhitespace": true
 }

--- a/lean4-infoview/src/infoview/contexts.ts
+++ b/lean4-infoview/src/infoview/contexts.ts
@@ -4,9 +4,12 @@ import { DocumentUri } from "vscode-languageserver-protocol";
 import { LeanDiagnostic, LeanFileProgressProcessingInfo } from "../lspTypes";
 import { EditorConnection } from "./editorConnection";
 import { InfoviewConfig, defaultInfoviewConfig } from "../infoviewApi";
+import { RpcSessions } from "./rpcSessions";
 
-// Type-unsafe initializer but we never render any components without a proper EditorContext.
+// Type-unsafe initializers for contexts which we immediately set up at the top-level.
 export const EditorContext = React.createContext<EditorConnection>(null as any);
+export const RpcContext = React.createContext<RpcSessions>(null as any);
+
 export const ConfigContext = React.createContext<InfoviewConfig>(defaultInfoviewConfig);
 export const DiagnosticsContext = React.createContext<Map<DocumentUri, LeanDiagnostic[]>>(new Map());
 export const ProgressContext = React.createContext<Map<DocumentUri, LeanFileProgressProcessingInfo[]>>(new Map());

--- a/lean4-infoview/src/infoview/editorConnection.ts
+++ b/lean4-infoview/src/infoview/editorConnection.ts
@@ -1,4 +1,4 @@
-import { ErrorCodes, Location, ShowDocumentParams } from "vscode-languageserver-protocol";
+import { Location, ShowDocumentParams } from "vscode-languageserver-protocol";
 
 import { Eventify } from "./event";
 import { DocumentPosition } from "./util";

--- a/lean4-infoview/src/infoview/main.tsx
+++ b/lean4-infoview/src/infoview/main.tsx
@@ -11,6 +11,7 @@ import { AllMessages } from './messages';
 import { useEvent, useServerNotificationState } from './util';
 import { LeanDiagnostic, LeanFileProgressParams, LeanFileProgressProcessingInfo } from '../lspTypes';
 import { EditorContext, ConfigContext, DiagnosticsContext, ProgressContext } from './contexts';
+import { WithRpcSessions } from './rpcSessions';
 import { EditorConnection, EditorEvents } from './editorConnection';
 import { defaultInfoviewConfig, EditorApi, InfoviewApi } from '../infoviewApi';
 import { Event } from './event';
@@ -54,12 +55,14 @@ function Main(props: {}) {
     <ConfigContext.Provider value={config}>
         <DiagnosticsContext.Provider value={allDiags}>
             <ProgressContext.Provider value={allProgress}>
-                <div className="ma1">
-                    <Infos />
-                    <div className="mv2">
-                        <AllMessages uri={curUri} />
+                <WithRpcSessions>
+                    <div className="ma1">
+                        <Infos />
+                        <div className="mv2">
+                            <AllMessages uri={curUri} />
+                        </div>
                     </div>
-                </div>
+                </WithRpcSessions>
             </ProgressContext.Provider>
         </DiagnosticsContext.Provider>
     </ConfigContext.Provider>

--- a/lean4-infoview/src/infoview/rpcSessions.tsx
+++ b/lean4-infoview/src/infoview/rpcSessions.tsx
@@ -1,0 +1,195 @@
+import React from "react"
+import { DocumentUri, TextDocumentPositionParams } from "vscode-languageserver-protocol"
+import { RpcPtr } from "../lspTypes"
+import { EditorContext, RpcContext } from "./contexts"
+import { EditorConnection } from "./editorConnection"
+import { DocumentPosition, useServerNotificationEffect } from "./util"
+
+interface RpcConnectParams {
+    uri: DocumentUri
+}
+
+interface RpcConnected {
+    uri: DocumentUri
+    sessionId: string
+}
+
+interface RpcCallParams extends TextDocumentPositionParams {
+    sessionId: string
+    method: string
+    params: any
+}
+
+interface RpcReleaseParams {
+    uri: DocumentUri
+    sessionId: string
+    ref: RpcPtr<any>
+}
+
+const RpcNeedsReconnect = -32900
+
+class RpcSession {
+    #ec: EditorConnection
+    #uri: DocumentUri
+    #finalizers: FinalizationRegistry<RpcPtr<any>>
+
+    constructor(readonly sessionId: string, uri: DocumentUri, ec: EditorConnection) {
+        this.#ec = ec
+        this.#uri = uri
+        // Here we hook into the JS GC and send release-reference requests whenever
+        // the GC finalizes an `RpcPtr`. Requires ES2021.
+        this.#finalizers = new FinalizationRegistry(ptr => {
+            const params: RpcReleaseParams = {
+                uri: this.#uri,
+                sessionId: this.sessionId,
+                ref: ptr,
+            }
+
+            // TODO(WN): batch multiple of these into a single notif
+            void this.#ec.api.sendClientNotification('$/lean/rpc/release', params)
+        })
+    }
+
+    async call(pos: DocumentPosition, method: string, params: any): Promise<any> {
+        const rpcParams: RpcCallParams = {
+            ...DocumentPosition.toTdpp(pos),
+            sessionId: this.sessionId,
+            method: method,
+            params: params,
+        }
+        return this.#ec.api.sendClientRequest('$/lean/rpc/call', rpcParams)
+            .then(val => {
+                // const s = JSON.stringify(val)
+                // console.log(`'${method}(${JSON.stringify(params)})' at '${pos.line}:${pos.character}' -> '${s.length < 200 ? s : '(..)'}'`)
+                return val
+            })
+    }
+
+    registerRef(ptr: RpcPtr<any>) {
+        this.#finalizers.register(ptr, RpcPtr.copy(ptr))
+    }
+}
+
+/** Provides an interface for making RPC calls to the Lean server. */
+export class RpcSessions {
+    /** Maps each URI to the connected RPC session, if any, at the corresponding file worker. */
+    #connected: Map<DocumentUri, RpcSession>
+    /** Like `#connected`, but for sessions which are currently connecting. */
+    #connecting: Map<DocumentUri, Promise<RpcSession>>
+    #ec: EditorConnection
+    setSelf: (_: (_: RpcSessions) => RpcSessions) => void
+
+    constructor(ec: EditorConnection) {
+        this.#connected = new Map()
+        this.#connecting = new Map()
+        this.#ec = ec
+        this.setSelf = () => { }
+    }
+
+    private async sessionAt(uri: DocumentUri): Promise<RpcSession | undefined> {
+        if (this.#connected.has(uri)) return this.#connected.get(uri)!
+        else if (this.#connecting.has(uri)) return this.#connecting.get(uri)!
+        else return undefined
+    }
+
+    private connectAt(uri: DocumentUri): void {
+        // NOTE(WN): a request would be slightly simpler to handle than a notification,
+        // but would complicate the server more.
+
+        if (this.#connecting.has(uri)) {
+            throw `already connecting at '${uri}'`
+        }
+        if (this.#connected.has(uri)) {
+            this.#connected.delete(uri)
+        }
+        const newSesh = new Promise<RpcSession>(resolve => {
+            const h = this.#ec.events.gotServerNotification.on(([method, params]) => {
+                if (method !== '$/lean/rpc/connected') return
+                const conn: RpcConnected = params
+                if (conn.uri !== uri) return
+                resolve(new RpcSession(params.sessionId, conn.uri, this.#ec))
+                h.dispose() // this works, somehow
+            })
+        })
+        this.#connecting.set(uri, newSesh)
+        const connParams: RpcConnectParams = { uri }
+        this.#ec.api.sendClientNotification('$/lean/rpc/connect', connParams)
+        newSesh.then(newSesh => {
+            this.#connected.set(uri, newSesh)
+            this.#connecting.delete(uri)
+
+            // Trigger a React update when we connect.
+            this.setSelf(rs => {
+                // The `RpcSessions` object is intentionally global with only a shallow copy here
+                const newRs = new RpcSessions(rs.#ec)
+                newRs.#connected = rs.#connected
+                newRs.#connecting = rs.#connecting
+                newRs.setSelf = rs.setSelf
+                return newRs
+            })
+        })
+    }
+
+    /**
+     * Executes an RPC call in the context of `pos`. If the relevant RPC session is not yet
+     * connected, returns `undefined` and then triggers a React update. See also `registerRef`.
+     */
+    async call<T>(pos: DocumentPosition, method: string, params: any): Promise<T | undefined> {
+        const sesh = await this.sessionAt(pos.uri)
+        if (!sesh) {
+            this.connectAt(pos.uri)
+            return undefined
+        }
+
+        try {
+            const ret = await sesh.call(pos, method, params)
+            return ret
+        } catch (ex) {
+            if (ex.code === RpcNeedsReconnect) {
+                // Are we reconnecting yet?
+                if (!this.#connecting.has(pos.uri)) {
+                    this.connectAt(pos.uri)
+                }
+                return undefined
+            }
+            console.error(`RPC error: ${JSON.stringify(ex)}`)
+            throw ex
+        }
+    }
+
+    /**
+     * All {@link RpcPtr}s received from the server must be registered for garbage
+     * collection through this method. Not doing so is safe but will leak memory.
+     */
+    registerRef(pos: DocumentPosition, ptr: RpcPtr<any>): void {
+        void this.sessionAt(pos.uri).then(sesh => {
+            if (sesh) sesh.registerRef(ptr)
+            else throw `tried to register ref in non-existent RPC session ${pos.uri}`
+        })
+    }
+
+    /**
+     * Returns an identifier for the RPC session at `uri`. When this changes, all components
+     * which may use RPC in the context of that document must be re-created to avoid using
+     * outdated references.
+     */
+    sessionIdAt(uri: DocumentUri): string {
+        if (this.#connected.has(uri)) return this.#connected.get(uri)!.sessionId
+        return ''
+    }
+}
+
+/** Manages a Lean RPC connection by providing an {@link RpcContext} to the children. */
+export function WithRpcSessions({ children }: { children: React.ReactNode }) {
+    const ec = React.useContext(EditorContext)
+    const [sessions, setSessions] = React.useState<RpcSessions>(new RpcSessions(ec))
+    sessions.setSelf = setSessions
+
+    useServerNotificationEffect('$/lean/rpc/connected', _ => {
+        // Just subscribe here, but actually handle internally
+    }, [])
+
+    return <RpcContext.Provider value={sessions}>
+        {children}
+    </RpcContext.Provider>
+}

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -139,7 +139,7 @@ export function useClientNotificationState<S, T>(method: string, initial: S, f: 
  * - for as long as `isPaused` is set, `tPausable` holds its initial value (the `t` passed before pausing)
  *   rather than updates with changes to `t`.
  * - `tRef` can be used to overwrite the paused state
- * 
+ *
  * To pause child components, `startPaused` can be passed in their props.
  */
 export function usePausableState<T>(startPaused: boolean, t: T): [boolean, React.Dispatch<React.SetStateAction<boolean>>, T, React.MutableRefObject<T>] {
@@ -167,8 +167,8 @@ export function useLogState(): [string, (...msg: any[]) => void] {
 export type Keyed<T> = T & { key: string };
 
 /**
- * Adds a unique `key` property to each element in `elems` starting from
- * the (possibly non-injective) values of `getId`.
+ * Adds a unique `key` property to each element in `elems` using
+ * the values of (possibly non-injective) `getId`.
  */
 export function addUniqueKeys<T>(elems: T[], getId: (el: T) => string): Keyed<T>[] {
     const keys: { [key: string]: number } = {};

--- a/lean4-infoview/src/lspTypes.ts
+++ b/lean4-infoview/src/lspTypes.ts
@@ -32,3 +32,20 @@ export interface LeanFileProgressParams {
      */
     processing: LeanFileProgressProcessingInfo[];
 }
+
+// https://stackoverflow.com/a/56749647
+declare const tag: unique symbol;
+export type RpcPtr<T> = { readonly [tag]: T, p: string }
+
+export namespace RpcPtr {
+
+export function copy<T>(p: RpcPtr<T>): RpcPtr<T> {
+    return { p: p.p } as RpcPtr<T>;
+}
+
+/** Turns a reference into a unique string. Useful for React `key`s. */
+export function toKey(p: RpcPtr<any>): string {
+    return p.p;
+}
+
+}

--- a/lean4-infoview/tsconfig.json
+++ b/lean4-infoview/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     /* Code generation */
-    "target": "es6",
-    "module": "es6",
+    "target": "ES2021",
+    "module": "ES6",
     "lib": [
       "dom",
       "dom.iterable",
-      "es6"
+      "ES2021"
     ],
     "allowJs": true,
     "jsx": "react-jsx",

--- a/vscode-lean4/src/rpc.ts
+++ b/vscode-lean4/src/rpc.ts
@@ -39,6 +39,7 @@ export class Rpc {
                 try {
                     this.sendMessage({ seqNum, result: await this.methods[name](...args) })
                 } catch (ex) {
+                    // TODO(WN): somehow `ex.message` is lost here on going through `webview.postMessage`
                     this.sendMessage({ seqNum, exception: ex === undefined ? 'error' : ex })
                 }
             })()


### PR DESCRIPTION
Adds support for receiving and using [`RpcRef`s](https://github.com/leanprover/lean4/blob/32bea737089f5153cef65e480601e2e610973222/src/Lean/Data/Lsp/Extra.lean#L71) in the client but does not do anything with it yet. Some points:
- We have to bump the target to ES2021 to hook into the JS GC with `FinalizationRegistry`. I don't think this is an issue -- we only intend to support recent Electron webviews and potentially Webkit ones.
- The "RPC" name collision is a bit confusing since we now have webview<->editor RPC and webview<->Lean RPC. Any ideas?