### PR TITLE
feat: add setting to configure server arguments

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -78,6 +78,15 @@
 						"description": "a path to add to the environment"
 					}
 				},
+				"lean4.serverArgs": {
+					"type": "array",
+					"default": [],
+					"description": "Arguments to pass to the Lean 4 server.",
+					"items": {
+						"type": "string",
+						"description": "an argument to pass to the server"
+					}
+				},
 				"lean4.serverLogging.enabled": {
 					"type": "boolean",
 					"default": false,

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -34,6 +34,10 @@ export function serverEnvPaths(): string[] {
     return workspace.getConfiguration('lean4').get('serverEnvPaths', [])
 }
 
+export function serverArgs(): string[] {
+    return workspace.getConfiguration('lean4').get('serverArgs', [])
+}
+
 export function serverLoggingEnabled(): boolean {
     return workspace.getConfiguration('lean4.serverLogging').get('enabled', false)
 }

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -13,7 +13,7 @@ import {
     ServerOptions,
 } from 'vscode-languageclient/node'
 import * as ls from 'vscode-languageserver-protocol'
-import { executablePath, addServerEnvPaths, serverLoggingEnabled, serverLoggingPath, getElaborationDelay } from './config'
+import { executablePath, addServerEnvPaths, serverArgs, serverLoggingEnabled, serverLoggingPath, getElaborationDelay } from './config'
 import { assert } from './utils/assert'
 import { PlainGoal, PlainTermGoal, LeanFileProgressParams, LeanFileProgressProcessingInfo } from '@lean4/infoview';
 
@@ -82,7 +82,7 @@ export class LeanClient implements Disposable {
         }
         const serverOptions: ServerOptions = {
             command: executablePath(),
-            args: ['--server'],
+            args: ['--server'].concat(serverArgs()),
             options: {
                 shell: true,
                 env


### PR DESCRIPTION
Users may wish to provide additional arguments to the Lean 4 server. For example, to add plugins or set other configuration options (ex. timeout), This PR adds a `serverArgs` setting to allow users to do just that.  